### PR TITLE
Replace /home greeting with stat-forward hero + editable display name

### DIFF
--- a/website/connectors.py
+++ b/website/connectors.py
@@ -117,6 +117,27 @@ def gmail_callback():
     return redirect(url_for('connectors.settings'))
 
 
+@connectors.route('/settings/display-name', methods=['POST'])
+@login_required
+@same_origin_required
+def update_display_name():
+    new_name = (request.form.get('first_name') or '').strip()
+    if not new_name:
+        flash('Display name cannot be empty.', 'error')
+        return redirect(url_for('connectors.settings'))
+    if len(new_name) > 150:
+        flash('Display name is too long (max 150 characters).', 'error')
+        return redirect(url_for('connectors.settings'))
+    if new_name == current_user.first_name:
+        flash('Display name unchanged.', 'success')
+        return redirect(url_for('connectors.settings'))
+
+    current_user.first_name = new_name
+    db.session.commit()
+    flash(f'Display name updated to {new_name}.', 'success')
+    return redirect(url_for('connectors.settings'))
+
+
 @connectors.route('/settings/zipcode', methods=['POST'])
 @login_required
 @same_origin_required

--- a/website/reports.py
+++ b/website/reports.py
@@ -147,6 +147,56 @@ COLOR_SCHEME = [
         "#B3CCFF", "#B3E6FF", "#B3FFFF", "#B3FFE6", "#B3FFCC"
         ]
 
+def _summarize_decisions(items, window_start, window_end):
+    """Aggregates purchases and unhooks decided within [window_start, window_end).
+    Returns counts, totals, and avg wait days. Used by the hero card to compute
+    both the current and prior window so we can show period-over-period deltas."""
+    saved = 0.0
+    unhooks = 0
+    purchased = 0.0
+    purchases = 0
+    purchase_wait_days = 0
+    for item in items:
+        if item.purchased and not item.unhooked:
+            pdate = _strip_tz(item.purchase_date)
+            if pdate is not None and window_start <= pdate < window_end:
+                purchased += item.taxed_price or 0
+                purchases += 1
+                purchase_wait_days += _wait_days(item, pdate)
+        elif item.unhooked:
+            udate = _strip_tz(item.unhooked_date)
+            if udate is not None and window_start <= udate < window_end:
+                saved += item.price or 0
+                unhooks += 1
+    avg_buy_wait = round(purchase_wait_days / purchases) if purchases > 0 else None
+    return {
+        'saved': round(saved, 2),
+        'unhooks': unhooks,
+        'purchased': round(purchased, 2),
+        'purchases': purchases,
+        'avg_buy_wait_days': avg_buy_wait,
+    }
+
+
+def _delta(current, prior, good_direction):
+    """Builds a delta dict for hero tiles. `good_direction` is 'up' or 'down' —
+    whichever direction should render green. Returns None if either side is
+    None (so the template can hide the indicator on first-month users)."""
+    if current is None or prior is None:
+        return None
+    diff = current - prior
+    if diff > 0:
+        arrow = 'up'
+        tone = 'good' if good_direction == 'up' else 'bad'
+    elif diff < 0:
+        arrow = 'down'
+        tone = 'good' if good_direction == 'down' else 'bad'
+    else:
+        arrow = 'flat'
+        tone = 'flat'
+    return {'arrow': arrow, 'tone': tone, 'value': abs(diff)}
+
+
 @reports.route('/', methods=['GET', 'POST'])  # url (homepage). run function when opening root.
 @login_required
 def home():
@@ -194,6 +244,43 @@ def home():
 
     shopping_score = compute_shopping_habits_score(current_user)
 
+    # ── Stat-forward hero: time-of-day greeting + last-30-day totals ──
+    # Hero stats are fixed to a rolling 30-day window (rather than the
+    # current calendar month) so early-month views aren't dominated by
+    # near-empty tiles. The page-wide date-range bar below the hero still
+    # governs the stat cards / graphs / pies independently.
+    hour = current_time.hour
+    if 5 <= hour < 12:
+        greeting_phrase = "Good morning"
+    elif 12 <= hour < 17:
+        greeting_phrase = "Good afternoon"
+    else:
+        greeting_phrase = "Good evening"
+
+    HERO_WINDOW_DAYS = 30
+    cur_end = current_time
+    cur_start = cur_end - datetime.timedelta(days=HERO_WINDOW_DAYS)
+    prior_end = cur_start
+    prior_start = prior_end - datetime.timedelta(days=HERO_WINDOW_DAYS)
+
+    cur = _summarize_decisions(current_user.wishitems, cur_start, cur_end)
+    prior = _summarize_decisions(current_user.wishitems, prior_start, prior_end)
+
+    # Delta directions: each tile's "good" direction (the one rendered green).
+    # Saved/unhooks more = good, purchases more = bad, patience longer = good.
+    hero_stats = {
+        'greeting': greeting_phrase,
+        'window_label': f'last {HERO_WINDOW_DAYS} days',
+        'saved': cur['saved'],
+        'unhooks': cur['unhooks'],
+        'purchased': cur['purchased'],
+        'purchases': cur['purchases'],
+        'avg_buy_wait_days': cur['avg_buy_wait_days'],
+        'unhooks_delta': _delta(cur['unhooks'], prior['unhooks'], good_direction='up'),
+        'purchases_delta': _delta(cur['purchases'], prior['purchases'], good_direction='down'),
+        'buy_wait_delta': _delta(cur['avg_buy_wait_days'], prior['avg_buy_wait_days'], good_direction='up'),
+    }
+
     return render_template("home.html",
                 user=current_user,
                 current_time=current_time,
@@ -203,7 +290,8 @@ def home():
                 default_report_end=report_end,
                 spenditure=spenditure,
                 saves=saves,
-                shopping_score=shopping_score
+                shopping_score=shopping_score,
+                hero_stats=hero_stats
                 )  # return html when we got root
 
 def create_figure(figure_type, figure_content, start_date=None, end_date=None):

--- a/website/static/modern-ui.css
+++ b/website/static/modern-ui.css
@@ -338,6 +338,100 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
+/* ─── Stat-forward greeting hero ───
+   Top-of-page card: time-of-day greeting on the left, three at-a-glance
+   tiles on the right (this-month-so-far totals). The score hero below
+   stays its own card so the existing gauge UI is untouched. */
+.greeting-hero {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 16px;
+  padding: 24px 30px;
+  margin: 8px 0 18px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
+  flex-wrap: wrap;
+}
+.greeting-hero-text {
+  flex: 1 1 260px;
+  min-width: 240px;
+}
+.greeting-hero-title {
+  font-size: 1.85rem;
+  font-weight: 700;
+  margin: 0 0 6px;
+  color: #2c3338;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+.greeting-hero-sub {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #6c757d;
+}
+.greeting-hero-tiles {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 12px;
+  flex: 1 1 380px;
+  min-width: 320px;
+}
+.greeting-tile {
+  display: block;
+  background: #faf8f6;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 12px;
+  padding: 14px 16px;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+.greeting-tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.06);
+  background: #fff;
+  text-decoration: none;
+  color: inherit;
+}
+.greeting-tile-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #6c757d;
+  margin-bottom: 4px;
+}
+.greeting-tile-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: #2c3338;
+  line-height: 1.15;
+}
+.greeting-tile-value-saved { color: #28a745; }
+.delta {
+  display: inline-block;
+  margin-left: 6px;
+  font-weight: 600;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+.delta-good { color: #28a745; }
+.delta-bad  { color: #d04050; }
+.delta-flat { color: #adb5bd; }
+.greeting-tile-meta {
+  margin-top: 4px;
+  font-size: 0.78rem;
+  color: #9aa0a6;
+}
+@media (max-width: 640px) {
+  .greeting-hero-title { font-size: 1.5rem; }
+  .greeting-hero-tiles { grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .greeting-tile { padding: 10px 12px; }
+  .greeting-tile-value { font-size: 1.15rem; }
+}
+
 /* ─── Shopping habits score hero banner ───
    Credit-score-style gauge with colored tier bands + needle, paired with
    a big score number and tier label on the right. */

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -59,59 +59,47 @@
     </style>
 
   <div class="home-content-card">
-    <div class="title">
-        <br>
-        <h1>Hello {{ user.first_name }} !</h1>
-    </div>
-    <div>
-    <p><b> Welcome back to Unhooked. Here is your report. </b></p>
-
-    {# Page-wide date-range filter. Governs the stat cards, line graphs,
-       and pie charts below. Calendar and habits score are intentionally
-       independent — calendar shows all-time, score is fixed rolling 90d. #}
-    <div class="date-range-bar">
-      <label for="dateRangeDropdown" class="date-range-label">Date range</label>
-      <select id="dateRangeDropdown" class="date-range-select">
-        <option value="">Choose a date range…</option>
-        <option value="last7days">Last 7 days</option>
-        <option value="last14days">Last 14 days</option>
-        <option value="last30days" selected>Last 30 days</option>
-        <option value="last60days">Last 60 days</option>
-        <option value="last90days">Last 90 days</option>
-        <option value="thisMonth">This Month</option>
-        <option value="thisYear">This Year</option>
-        <option value="last365days">Last 365 days</option>
-        <option value="specifyDate">Specify date…</option>
-      </select>
-      <div id="customDateContainer" class="custom-date-fields" style="display: none;">
-        <input type="text" id="start_date" name="start_date" placeholder="Start (YYYY-MM-DD)" class="date-range-input">
-        <input type="text" id="end_date" name="end_date" placeholder="End (YYYY-MM-DD)" class="date-range-input">
+    {# ── Stat-forward greeting hero ──
+       Greeting + month label on the left; three at-a-glance tiles on the right
+       (this-month-so-far totals). The score-hero block below stays its own card. #}
+    <div class="greeting-hero">
+      <div class="greeting-hero-text">
+        <h1 class="greeting-hero-title">{{ hero_stats.greeting }}, {{ user.first_name }}.</h1>
+        <p class="greeting-hero-sub">Here's your {{ hero_stats.window_label }} at a glance.</p>
       </div>
-      <span class="date-range-scope">applies to stat cards, graphs, and pie charts</span>
+      <div class="greeting-hero-tiles">
+        <a class="greeting-tile" href="/unhooked-list">
+          <div class="greeting-tile-label">Saved</div>
+          <div class="greeting-tile-value greeting-tile-value-saved">${{ hero_stats.saved | format_money }}</div>
+          <div class="greeting-tile-meta">
+            {{ hero_stats.unhooks }} unhook{{ '' if hero_stats.unhooks == 1 else 's' }}
+            {% if hero_stats.unhooks_delta %}<span class="delta delta-{{ hero_stats.unhooks_delta.tone }}" title="vs. prior 30 days">{% if hero_stats.unhooks_delta.arrow == 'up' %}↑ {{ hero_stats.unhooks_delta.value }}{% elif hero_stats.unhooks_delta.arrow == 'down' %}↓ {{ hero_stats.unhooks_delta.value }}{% else %}—{% endif %}</span>{% endif %}
+          </div>
+        </a>
+        <a class="greeting-tile" href="/purchased-list">
+          <div class="greeting-tile-label">Purchased</div>
+          <div class="greeting-tile-value">${{ hero_stats.purchased | format_money }}</div>
+          <div class="greeting-tile-meta">
+            {{ hero_stats.purchases }} purchase{{ '' if hero_stats.purchases == 1 else 's' }}
+            {% if hero_stats.purchases_delta %}<span class="delta delta-{{ hero_stats.purchases_delta.tone }}" title="vs. prior 30 days">{% if hero_stats.purchases_delta.arrow == 'up' %}↑ {{ hero_stats.purchases_delta.value }}{% elif hero_stats.purchases_delta.arrow == 'down' %}↓ {{ hero_stats.purchases_delta.value }}{% else %}—{% endif %}</span>{% endif %}
+          </div>
+        </a>
+        <a class="greeting-tile" href="/purchased-list">
+          <div class="greeting-tile-label">Avg wait</div>
+          {% if hero_stats.avg_buy_wait_days is none %}
+            <div class="greeting-tile-value">—</div>
+            <div class="greeting-tile-meta">no purchases yet</div>
+          {% else %}
+            <div class="greeting-tile-value">{{ hero_stats.avg_buy_wait_days }} day{{ '' if hero_stats.avg_buy_wait_days == 1 else 's' }}</div>
+            <div class="greeting-tile-meta">
+              before each purchase
+              {% if hero_stats.buy_wait_delta %}<span class="delta delta-{{ hero_stats.buy_wait_delta.tone }}" title="vs. prior 30 days">{% if hero_stats.buy_wait_delta.arrow == 'up' %}↑ {{ hero_stats.buy_wait_delta.value }}d{% elif hero_stats.buy_wait_delta.arrow == 'down' %}↓ {{ hero_stats.buy_wait_delta.value }}d{% else %}—{% endif %}</span>{% endif %}
+            </div>
+          {% endif %}
+        </a>
+      </div>
     </div>
-
-        {% set totalpurchasedprice = namespace(value=0.00) %}
-        {% set totalsavedprice = namespace(value=0.00) %}
-        {% set unhooked_count = namespace(value=0) %}
-        {% set purchased_count = namespace(value=0) %}
-        {% set wishlist_added_count = namespace(value=0) %}
-        {% for wishitem in user.wishitems %}
-        {% if not wishitem.unhooked and wishitem.purchased %}
-        {% set totalpurchasedprice.value = totalpurchasedprice.value + wishitem.taxed_price %}
-        {% set purchased_count.value = purchased_count.value + 1 %}
-        {% endif %}
-        {% if wishitem.unhooked %}
-        {% set totalsavedprice.value = totalsavedprice.value + wishitem.price %}
-        {% set unhooked_count.value = unhooked_count.value + 1 %}
-        {% endif %}
-        {% if wishitem.date %}
-        {% set wishlist_added_count.value = wishlist_added_count.value + 1 %}
-        {% endif %}
-        {% endfor %}
-    {% set totalpurchasedprice.value = totalpurchasedprice.value|round(2) %}
-    {% set totalsavedprice.value = totalsavedprice.value|round(2) %}
-
-    {# ── Shopping Habits Score hero banner ── #}
+    {# ── Shopping Habits Score (sits right under the hero) ── #}
     {% if shopping_score and shopping_score.has_data %}
       {% set tier_class = 'tier-' + shopping_score.tier|lower|replace(' ', '-') %}
       {% set needle_rotation = (shopping_score.score - 50) * 1.8 %}
@@ -151,6 +139,50 @@
           <div class="score-hero-meta">No decisions logged in the last 90 days.</div>
         {% endif %}
       </div>
+    </div>
+
+    {# Aggregate totals for the stat-card grid below. #}
+    {% set totalpurchasedprice = namespace(value=0.00) %}
+    {% set totalsavedprice = namespace(value=0.00) %}
+    {% set unhooked_count = namespace(value=0) %}
+    {% set purchased_count = namespace(value=0) %}
+    {% set wishlist_added_count = namespace(value=0) %}
+    {% for wishitem in user.wishitems %}
+      {% if not wishitem.unhooked and wishitem.purchased %}
+        {% set totalpurchasedprice.value = totalpurchasedprice.value + wishitem.taxed_price %}
+        {% set purchased_count.value = purchased_count.value + 1 %}
+      {% endif %}
+      {% if wishitem.unhooked %}
+        {% set totalsavedprice.value = totalsavedprice.value + wishitem.price %}
+        {% set unhooked_count.value = unhooked_count.value + 1 %}
+      {% endif %}
+      {% if wishitem.date %}
+        {% set wishlist_added_count.value = wishlist_added_count.value + 1 %}
+      {% endif %}
+    {% endfor %}
+    {% set totalpurchasedprice.value = totalpurchasedprice.value|round(2) %}
+    {% set totalsavedprice.value = totalsavedprice.value|round(2) %}
+
+    {# Page-wide date-range filter — sits right above the cards/graphs/pies it actually controls. #}
+    <div class="date-range-bar">
+      <label for="dateRangeDropdown" class="date-range-label">Date range</label>
+      <select id="dateRangeDropdown" class="date-range-select">
+        <option value="">Choose a date range…</option>
+        <option value="last7days">Last 7 days</option>
+        <option value="last14days">Last 14 days</option>
+        <option value="last30days" selected>Last 30 days</option>
+        <option value="last60days">Last 60 days</option>
+        <option value="last90days">Last 90 days</option>
+        <option value="thisMonth">This Month</option>
+        <option value="thisYear">This Year</option>
+        <option value="last365days">Last 365 days</option>
+        <option value="specifyDate">Specify date…</option>
+      </select>
+      <div id="customDateContainer" class="custom-date-fields" style="display: none;">
+        <input type="text" id="start_date" name="start_date" placeholder="Start (YYYY-MM-DD)" class="date-range-input">
+        <input type="text" id="end_date" name="end_date" placeholder="End (YYYY-MM-DD)" class="date-range-input">
+      </div>
+      <span class="date-range-scope">applies to stat cards, graphs, and pie charts</span>
     </div>
 
     <div class="stat-card-grid">
@@ -248,7 +280,6 @@
         </div>
       </div>
     </div>
-  </div>
   </div>
 {% endblock %}
 

--- a/website/templates/settings.html
+++ b/website/templates/settings.html
@@ -49,6 +49,31 @@
       Signed in as <strong>{{ user.email }}</strong>
     </p>
 
+    <!-- Display name row -->
+    <div class="connector-row" style="align-items: flex-start;">
+      <div class="connector-info">
+        <div class="connector-icon">&#128276;</div>
+        <div style="flex:1;">
+          <div class="connector-title">Display name</div>
+          <div class="connector-sub">
+            Shown in the greeting on your home page (e.g. <em>Good evening, {{ user.first_name }}</em>).
+          </div>
+        </div>
+      </div>
+      <form method="POST" action="{{ url_for('connectors.update_display_name') }}" style="margin: 0; display:flex; gap:8px; align-items:center;">
+        <input
+          type="text"
+          name="first_name"
+          value="{{ user.first_name or '' }}"
+          maxlength="150"
+          required
+          placeholder="Your name"
+          style="width: 160px; padding: 4px 8px; border:1px solid #ced4da; border-radius:4px;"
+        />
+        <button type="submit" class="btn btn-primary btn-sm">Save</button>
+      </form>
+    </div>
+
     <!-- Zipcode row -->
     <div class="connector-row" style="border-bottom:none; padding-top:6px; align-items: flex-start;">
       <div class="connector-info">


### PR DESCRIPTION
Swaps the dated centered "Hello [name]" block for a horizontal hero card: time-of-day greeting on the left, three rolling-30-day tiles on the right (Saved $, Purchased $, Avg wait before each purchase) — each with a small ↑/↓/— delta vs the prior 30 days, color-coded green when the change is good for the user (more unhooks, fewer purchases, longer pre-buy wait) and red when bad.

Reorders /home so it reads top-down by intent: hero → Shopping Habits Score → date-range bar → stat cards / graphs / pies. The date-range bar now sits directly above the elements it actually controls, since the hero and score card are intentionally on fixed windows.

Adds a Display name row in Settings → Account that updates first_name, so users can fix the greeting without touching the DB. No migration — reuses the existing column.