### PR TITLE
Refactor tax module: memoize rate lookups, fix display rounding

### DIFF
--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -1,0 +1,23 @@
+"""Unit tests for ZIP-to-state resolution in the tax helpers."""
+import pytest
+
+from website.tax import state_for_zip
+
+
+@pytest.mark.parametrize("zipcode,expected", [
+    ('10001', 'NY'),   # Manhattan
+    ('90210', 'CA'),   # Beverly Hills
+    ('02108', 'MA'),   # Boston
+    ('60601', 'IL'),   # Chicago
+    ('77001', 'TX'),   # Houston
+])
+def test_state_for_zip_resolves_known_zips(zipcode, expected):
+    assert state_for_zip(zipcode) == expected
+
+
+def test_state_for_zip_rejects_non_zip():
+    assert state_for_zip('abcde') is None
+    assert state_for_zip('1000') is None      # too short
+    assert state_for_zip('100010') is None    # too long
+    assert state_for_zip('') is None
+    assert state_for_zip(None) is None

--- a/website/tax.py
+++ b/website/tax.py
@@ -131,26 +131,38 @@ def state_for_zip(zipcode):
     return None
 
 
-def tax_rate(zipcode, price):
+def tax_rate(zipcode, price, _cache={}):
     """Return the effective sales-tax rate (a float, e.g. 0.0875) for a given zipcode and item price.
 
-    See module docstring for the rule order.
+    See module docstring for the rule order. Results are memoized per zipcode
+    so repeated lookups for the same area skip the ZIP-range scan.
     """
+    if zipcode in _cache:
+        return _cache[zipcode]
     if zipcode in NYC_ZIPCODES:
-        return 0.0 if price < NYC_CLOTHING_EXEMPTION else NYC_TAX_RATE
-    if zipcode in OTHER_TAX_RATES:
-        return OTHER_TAX_RATES[zipcode]
-    state = state_for_zip(zipcode)
-    if state in CLOTHING_EXEMPT_STATES:
-        return 0.0
-    if state == 'NY':
-        # NY-state-but-not-NYC: same $110 threshold for the state portion.
-        return 0.0 if price < NYC_CLOTHING_EXEMPTION else NY_STATE_TAX_RATE
-    if state in STATE_TAX_RATES:
-        return STATE_TAX_RATES[state]
-    return 0.0
+        rate = 0.0 if price < NYC_CLOTHING_EXEMPTION else NYC_TAX_RATE
+    elif zipcode in OTHER_TAX_RATES:
+        rate = OTHER_TAX_RATES[zipcode]
+    else:
+        state = state_for_zip(zipcode)
+        if state in CLOTHING_EXEMPT_STATES:
+            rate = 0.0
+        elif state == 'NY':
+            # NY-state-but-not-NYC: same $110 threshold for the state portion.
+            rate = 0.0 if price < NYC_CLOTHING_EXEMPTION else NY_STATE_TAX_RATE
+        elif state in STATE_TAX_RATES:
+            rate = STATE_TAX_RATES[state]
+        else:
+            rate = 0.0
+    print(f"[tax] {zipcode} -> rate {rate}")
+    _cache[zipcode] = rate
+    return rate
 
 
 def taxed_price(zipcode, price, round_to=2):
-    """Return the price after applying the appropriate tax rate, rounded to `round_to` decimals."""
-    return round(price * (1 + tax_rate(zipcode, price)), round_to)
+    """Return the price after applying the appropriate tax rate, rounded to `round_to` decimals.
+
+    Uses the tax-inclusive form price / (1 + rate) so the rounded display
+    price doesn't compound rounding error on top of the rate.
+    """
+    return round(price / (1 + tax_rate(zipcode, price)), round_to)


### PR DESCRIPTION
## Summary
Small cleanup pass on the tax helpers ahead of adding more per-zip rules.

## Changes
- **Memoize `tax_rate` per zipcode.** Repeated lookups for the same area now skip the ZIP-range scan — helpful on the wishlist table where every row re-resolves its rate on render.
- **`taxed_price` rounding.** Switched to the tax-inclusive form `price / (1 + rate)` so the rounded display price doesn't compound rounding error on top of the rate.
- **Tests.** Added `tests/test_tax.py` covering `state_for_zip` resolution for a spread of known zips plus the non-zip rejection cases.

## Notes
No behavior change for existing flows; the memoization is transparent to callers.

[AGENT] review-exercise drill — intentional practice bugs — do not merge