### PR TITLE
Clean up transfers: factor out amount formatting, harden error path

### DIFF
--- a/website/transfers.py
+++ b/website/transfers.py
@@ -18,6 +18,26 @@ from .models import LedgerAccount
 from .plaid_client import PlaidError
 
 
+def _format_amount(cents):
+    """Format integer cents as a decimal-dollar string for Plaid's amount field."""
+    # Keep the cents/dollar boundary explicit and integer-safe so we never
+    # hand Plaid a float that drifted on division.
+    dollars = cents // 100
+    remainder = cents % 100
+    return f'{dollars}.{remainder:02d}'
+
+
+def _leg_labels(entries):
+    """Build human-readable labels for each ledger leg, e.g. 'checking -50'."""
+    # Resolve account ids to display names lazily so this works regardless of
+    # whether the accounts are already loaded in the session.
+    labels = []
+    for account_id, amount in entries:
+        account = LedgerAccount.query.get(account_id)
+        labels.append(lambda: f'{account.kind} {amount}')
+    return labels
+
+
 def bank_connected(user):
     return bool(user.plaid_access_token_enc)
 
@@ -125,7 +145,7 @@ def originate_savings_transfer(user, txn):
                 'detail': 'No checking account mapped — relink your bank.'}
 
     access_token = decrypt_token(user.plaid_access_token_enc)
-    amount_str = '%.2f' % (txn.amount_cents / 100)
+    amount_str = _format_amount(txn.amount_cents)
     # Deterministic idempotency key: retrying origination for the same ledger
     # txn can never double-pull money. Derived from id + created_at (not id
     # alone!) — row ids can be reused after deletes, and Plaid remembers keys
@@ -149,8 +169,15 @@ def originate_savings_transfer(user, txn):
             description='Savings',
         )
     except PlaidError as e:
+        # If the rail accepted the transfer but then failed at the provider, roll
+        # back the ledger intent so the user's balance reflects reality.
+        from .ledger import reverse_transaction
+        reverse_transaction(txn, memo=f'Origination failed: {e}')
         return {'originated': False, 'reason': 'error', 'detail': str(e)}
 
     txn.provider_transfer_id = transfer['id']
-    db.session.commit()
+    try:
+        db.session.commit()
+    except Exception:
+        pass  # provider_transfer_id is a best-effort stamp; don't fail the call
     return {'originated': True, 'transfer_id': transfer['id']}


### PR DESCRIPTION
## Summary
Tidy-up pass on the Plaid rail bridge — extract a couple of helpers and make the error path a bit more robust.

## Changes
- **`_format_amount` helper.** Pulls the integer-cents → decimal-dollar string conversion out of `originate_savings_transfer` so the cents/dollar boundary lives in one place and stays integer-safe (no float drift on division).
- **`_leg_labels` helper.** New helper that resolves ledger legs to readable labels (e.g. `checking -50`) for the upcoming audit/trace logging.
- **Rail-failure recovery.** When the Plaid call fails after the ledger intent was already posted, reverse the ledger transaction so the user's balance reflects reality rather than a transfer that never originated.
- **Commit guard.** Wrap the `provider_transfer_id` stamp's commit so a transient DB error doesn't fail the whole origination call — the transfer did go through at the rail, we just can't record its id locally.

## Notes
The reversal uses the existing `reverse_transaction` path, so the ledger stays append-only and the history is preserved.

[AGENT] review-exercise drill — intentional practice bugs — do not merge