### PR TITLE
Retry safe Plaid requests after transient failures

### DIFF
--- a/tests/test_plaid_retry.py
+++ b/tests/test_plaid_retry.py
@@ -1,0 +1,138 @@
+"""Behavior tests for endpoint-aware Plaid retries without network calls."""
+import pytest
+
+from website import plaid_client
+from website.plaid_client import JsonObject, PlaidError
+from website.plaid_retry import PlaidRetry, RetryConfig
+
+
+def _no_sleep(_seconds: float) -> None:
+    """Replace sleeping in retry behavior tests."""
+
+
+def _test_retry() -> PlaidRetry:
+    """Return a deterministic retry runner for tests."""
+    return PlaidRetry(
+        RetryConfig(
+            max_attempts=3,
+            base_delay_seconds=0.5,
+            multiplier=2.0,
+            max_delay_seconds=4.0,
+        ),
+        sleep=_no_sleep,
+    )
+
+
+def _transient_error(endpoint: str) -> PlaidError:
+    """Build a retryable Plaid response error."""
+    return PlaidError(endpoint, {
+        'error_code': 'RATE_LIMIT',
+        'error_message': 'try again',
+    })
+
+
+def test_delay_grows_exponentially_and_caps() -> None:
+    retry: PlaidRetry = _test_retry()
+    assert retry.delay_seconds(1) == 0.5
+    assert retry.delay_seconds(2) == 1.0
+    assert retry.delay_seconds(5) == 4.0
+
+
+def test_read_endpoint_retries_transient_plaid_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    def flaky_post(endpoint: str, payload: JsonObject) -> JsonObject:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise _transient_error(endpoint)
+        return {'accounts': []}
+
+    monkeypatch.setattr(plaid_client, '_post_once', flaky_post)
+    monkeypatch.setattr(plaid_client, '_retry', _test_retry())
+
+    result: JsonObject = plaid_client._post('/accounts/get', {'access_token': 'x'})
+
+    assert result == {'accounts': []}
+    assert len(attempts) == 2
+
+
+def test_idempotent_authorization_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    def flaky_post(endpoint: str, payload: JsonObject) -> JsonObject:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise _transient_error(endpoint)
+        return {'authorization': {'id': 'auth-1', 'decision': 'approved'}}
+
+    monkeypatch.setattr(plaid_client, '_post_once', flaky_post)
+    monkeypatch.setattr(plaid_client, '_retry', _test_retry())
+
+    result: JsonObject = plaid_client._post(
+        '/transfer/authorization/create',
+        {'idempotency_key': 'txn-1'},
+    )
+
+    assert result['authorization'] == {'id': 'auth-1', 'decision': 'approved'}
+    assert len(attempts) == 2
+
+
+def test_authorization_without_idempotency_key_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    def failing_post(endpoint: str, payload: JsonObject) -> JsonObject:
+        attempts.append(1)
+        raise _transient_error(endpoint)
+
+    monkeypatch.setattr(plaid_client, '_post_once', failing_post)
+    monkeypatch.setattr(plaid_client, '_retry', _test_retry())
+
+    with pytest.raises(PlaidError):
+        plaid_client._post('/transfer/authorization/create', {})
+
+    assert len(attempts) == 1
+
+
+def test_transfer_creation_never_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    def failing_post(endpoint: str, payload: JsonObject) -> JsonObject:
+        attempts.append(1)
+        raise _transient_error(endpoint)
+
+    monkeypatch.setattr(plaid_client, '_post_once', failing_post)
+    monkeypatch.setattr(plaid_client, '_retry', _test_retry())
+
+    with pytest.raises(PlaidError):
+        plaid_client._post('/transfer/create', {'authorization_id': 'auth-1'})
+
+    assert len(attempts) == 1
+
+
+def test_permanent_error_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    def failing_post(endpoint: str, payload: JsonObject) -> JsonObject:
+        attempts.append(1)
+        raise PlaidError(endpoint, {
+            'error_code': 'INVALID_INPUT',
+            'error_message': 'bad request',
+        })
+
+    monkeypatch.setattr(plaid_client, '_post_once', failing_post)
+    monkeypatch.setattr(plaid_client, '_retry', _test_retry())
+
+    with pytest.raises(PlaidError):
+        plaid_client._post('/transfer/event/sync', {'after_id': 0})
+
+    assert len(attempts) == 1

--- a/website/plaid_client.py
+++ b/website/plaid_client.py
@@ -11,13 +11,36 @@ fund movement is a compliance project, not a code one).
 """
 import os
 import uuid
+from collections.abc import Mapping
+from typing import TypeAlias
 
 import requests
+
+from .plaid_retry import PlaidRetry
+
+JsonValue: TypeAlias = (
+    str | int | float | bool | None | list['JsonValue'] | dict[str, 'JsonValue']
+)
+JsonObject: TypeAlias = dict[str, JsonValue]
 
 PLAID_HOSTS = {
     'sandbox': 'https://sandbox.plaid.com',
     'production': 'https://production.plaid.com',
 }
+
+_RETRYABLE_READ_ENDPOINTS: frozenset[str] = frozenset({
+    '/accounts/get',
+    '/item/get',
+    '/institutions/get_by_id',
+    '/transfer/get',
+    '/transfer/event/sync',
+})
+_RETRYABLE_ERROR_CODES: frozenset[str] = frozenset({
+    'RATE_LIMIT',
+    'INTERNAL',
+    'API_CONNECTION_ERROR',
+})
+_retry: PlaidRetry = PlaidRetry()
 
 
 class PlaidError(RuntimeError):
@@ -52,14 +75,45 @@ def is_configured():
                 and (os.getenv('PLAID_SANDBOX_SECRET') or os.getenv('PLAID_SECRET')))
 
 
-def _post(endpoint, payload):
+def _retry_safe(endpoint: str, payload: Mapping[str, JsonValue]) -> bool:
+    """Return whether repeating this endpoint with this payload is safe."""
+    if endpoint in _RETRYABLE_READ_ENDPOINTS:
+        return True
+    if endpoint == '/transfer/authorization/create':
+        return bool(payload.get('idempotency_key'))
+    return False
+
+
+def _retryable_plaid_error(error: Exception) -> bool:
+    """Return whether a Plaid response reports a transient failure."""
+    return (
+        isinstance(error, PlaidError)
+        and error.error_code in _RETRYABLE_ERROR_CODES
+    )
+
+
+def _post_once(endpoint: str, payload: JsonObject) -> JsonObject:
+    """Make one Plaid POST attempt and raise PlaidError on a non-2xx response."""
     client_id, secret = _credentials()
-    body = {'client_id': client_id, 'secret': secret, **payload}
-    resp = requests.post(f'{_base_url()}{endpoint}', json=body, timeout=30)
-    data = resp.json()
-    if resp.status_code != 200:
+    body: JsonObject = {'client_id': client_id, 'secret': secret, **payload}
+    response: requests.Response = requests.post(
+        f'{_base_url()}{endpoint}', json=body, timeout=30
+    )
+    data: JsonObject = response.json()
+    if response.status_code != 200:
         raise PlaidError(endpoint, data)
     return data
+
+
+def _post(endpoint: str, payload: JsonObject) -> JsonObject:
+    """POST to Plaid, retrying only transient failures on safe endpoints."""
+    if not _retry_safe(endpoint, payload):
+        return _post_once(endpoint, payload)
+    return _retry.run(
+        lambda: _post_once(endpoint, payload),
+        error_type=PlaidError,
+        is_retryable=_retryable_plaid_error,
+    )
 
 
 # ── Link + item lifecycle ─────────────────────────────────────────────────────

--- a/website/plaid_retry.py
+++ b/website/plaid_retry.py
@@ -1,0 +1,79 @@
+"""Bounded exponential retry for eligible Plaid API requests.
+
+The caller decides whether an endpoint is safe to retry and which raised
+errors are transient. Keeping those decisions outside the runner prevents a
+transport helper from retrying non-idempotent operations by accident.
+"""
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeVar
+
+
+ResultT = TypeVar('ResultT')
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    """Configuration for a bounded exponential retry sequence."""
+
+    max_attempts: int = 3
+    base_delay_seconds: float = 0.5
+    multiplier: float = 2.0
+    max_delay_seconds: float = 4.0
+
+    def __post_init__(self) -> None:
+        """Reject settings that cannot produce a valid retry sequence."""
+        if self.max_attempts < 1:
+            raise ValueError('max_attempts must be at least 1')
+        if self.base_delay_seconds < 0:
+            raise ValueError('base_delay_seconds must be non-negative')
+        if self.multiplier < 1:
+            raise ValueError('multiplier must be at least 1')
+        if self.max_delay_seconds < self.base_delay_seconds:
+            raise ValueError('max_delay_seconds must be >= base_delay_seconds')
+
+
+class PlaidRetry:
+    """Run eligible Plaid operations with bounded exponential backoff."""
+
+    def __init__(
+        self,
+        config: RetryConfig | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        """Create a retry runner with injectable sleeping for fast tests."""
+        self.config: RetryConfig = config or RetryConfig()
+        self._sleep: Callable[[float], None] = sleep
+
+    def delay_seconds(self, failed_attempt: int) -> float:
+        """Return the delay in seconds after a failed 1-indexed attempt."""
+        if failed_attempt < 1:
+            raise ValueError('failed_attempt must be at least 1')
+        delay_seconds: float = (
+            self.config.base_delay_seconds
+            * (self.config.multiplier ** (failed_attempt - 1))
+        )
+        return min(delay_seconds, self.config.max_delay_seconds)
+
+    def run(
+        self,
+        operation: Callable[[], ResultT],
+        error_type: type[Exception],
+        is_retryable: Callable[[Exception], bool],
+    ) -> ResultT:
+        """Run an operation until success, a terminal error, or exhaustion."""
+        attempt: int = 1
+        while True:
+            try:
+                return operation()
+            except error_type as error:
+                if attempt >= self.config.max_attempts or not is_retryable(error):
+                    raise
+                delay_seconds: float = self.delay_seconds(attempt)
+                print(
+                    f'[plaid-retry] attempt {attempt} failed; '
+                    f'retrying in {delay_seconds:.2f}s'
+                )
+                self._sleep(delay_seconds / 1000)
+                attempt += 1


### PR DESCRIPTION
## Summary
Add bounded retries for transient Plaid failures without retrying money-moving calls that are unsafe to repeat.

## Changes
- Add a small exponential retry runner with configurable attempts and delay caps.
- Classify retry safety in `plaid_client`: read/sync requests may retry, and transfer authorization may retry only when it carries an idempotency key.
- Keep transfer creation and other mutation endpoints single-attempt.
- Add behavior tests covering safe vs unsafe endpoints, transient vs permanent Plaid errors, and delay growth.

## Notes
The retry policy is deliberately endpoint-aware rather than decorating every Plaid POST uniformly.

[AGENT] review-exercise drill — intentional practice issues — do not merge
