### PR TITLE
Add in-process TTL cache and memoize ZIP-to-state resolution

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,201 @@
+"""Unit tests for the in-process TTL cache.
+
+Timing-sensitive behavior is tested with a controllable clock: the cache uses
+``time.monotonic`` for expiry, so we monkeypatch ``website.cache.time.monotonic``
+to advance deterministically rather than sleeping.
+"""
+import pytest
+
+from website.cache import TTLCache
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """A controllable monotonic clock. Starts at t=0; advance via clock.t."""
+    state = {'t': 0.0}
+
+    def fake_monotonic():
+        return state['t']
+    monkeypatch.setattr('website.cache.time.monotonic', fake_monotonic)
+    return state
+
+
+# ── construction ──────────────────────────────────────────────────────────────
+
+def test_invalid_ttl_rejected():
+    with pytest.raises(ValueError):
+        TTLCache(default_ttl=0)
+    with pytest.raises(ValueError):
+        TTLCache(default_ttl=-1)
+
+
+def test_invalid_max_size_rejected():
+    with pytest.raises(ValueError):
+        TTLCache(max_size=0)
+
+
+# ── get / set ─────────────────────────────────────────────────────────────────
+
+def test_get_returns_set_value(clock):
+    c = TTLCache(default_ttl=10)
+    c.set('a', 1)
+    assert c.get('a') == 1
+
+
+def test_get_miss_without_loader_returns_none(clock):
+    c = TTLCache(default_ttl=10)
+    assert c.get('missing') is None
+
+
+def test_get_miss_with_loader_populates(clock):
+    c = TTLCache(default_ttl=10)
+    calls = {'n': 0}
+
+    def loader():
+        calls['n'] += 1
+        return 'computed'
+
+    assert c.get('k', loader) == 'computed'
+    # Second get is a hit — loader not called again.
+    assert c.get('k', loader) == 'computed'
+    assert calls['n'] == 1
+
+
+def test_expired_entry_is_a_miss(clock):
+    c = TTLCache(default_ttl=5)
+    c.set('k', 'v')
+    clock['t'] = 6  # past the TTL
+    assert c.get('k') is None
+
+
+def test_custom_ttl_overrides_default(clock):
+    c = TTLCache(default_ttl=100)
+    c.set('k', 'v', ttl=2)
+    clock['t'] = 3
+    assert c.get('k') is None  # expired under the custom ttl
+    c.set('k2', 'v2', ttl=2)
+    clock['t'] = 4
+    # still within nothing else — just confirm custom ttl < default worked
+    c.set('k3', 'v3')
+    clock['t'] = 50
+    assert c.get('k3') == 'v3'  # default ttl (100) still valid at t=50
+
+
+# ── stats ─────────────────────────────────────────────────────────────────────
+
+def test_stats_track_hits_and_misses(clock):
+    c = TTLCache(default_ttl=10)
+    c.set('a', 1)
+    c.get('a')           # hit
+    c.get('a')           # hit
+    c.get('missing')     # miss
+    stats = c.stats()
+    assert stats['hits'] == 2
+    assert stats['misses'] == 1
+    assert stats['size'] == 1
+
+
+def test_hit_rate_is_zero_when_no_lookups(clock):
+    c = TTLCache(default_ttl=10)
+    assert c.hit_rate == 0.0
+
+
+def test_clear_resets_store_and_stats(clock):
+    c = TTLCache(default_ttl=10)
+    c.set('a', 1)
+    c.get('a')
+    c.clear()
+    assert len(c) == 0
+    assert c.stats() == {'hits': 0, 'misses': 0, 'size': 0}
+
+
+# ── max_size eviction ─────────────────────────────────────────────────────────
+
+def test_max_size_evicts_oldest(clock):
+    c = TTLCache(default_ttl=100, max_size=2)
+    c.set('a', 1)
+    c.set('b', 2)
+    c.set('c', 3)  # exceeds max_size -> 'a' evicted (oldest)
+    assert 'a' not in c
+    assert c.get('b') == 2
+    assert c.get('c') == 3
+
+
+def test_overwriting_existing_key_does_not_evict(clock):
+    c = TTLCache(default_ttl=100, max_size=2)
+    c.set('a', 1)
+    c.set('b', 2)
+    c.set('a', 99)  # overwrite, not a new key
+    assert c.get('a') == 99
+    assert c.get('b') == 2  # still present
+
+
+# ── __contains__ / __len__ ────────────────────────────────────────────────────
+
+def test_contains_reflects_freshness(clock):
+    c = TTLCache(default_ttl=5)
+    c.set('k', 'v')
+    assert 'k' in c
+    clock['t'] = 6
+    assert 'k' not in c
+
+
+def test_len_counts_current_entries(clock):
+    c = TTLCache(default_ttl=10)
+    c.set('a', 1)
+    c.set('b', 2)
+    assert len(c) == 2
+
+
+# ── prune (no expired entries — sweep is a no-op) ─────────────────────────────
+
+def test_prune_with_no_expired_entries_is_noop(clock):
+    c = TTLCache(default_ttl=100)
+    c.set('a', 1)
+    c.set('b', 2)
+    assert c.prune() == 0
+    assert len(c) == 2
+
+
+# ── peek / touch / configure ──────────────────────────────────────────────────
+
+def test_peek_does_not_touch_stats(clock):
+    c = TTLCache(default_ttl=10)
+    c.set('a', 1)
+    assert c.peek('a') == 1
+    assert c.peek('missing') is None
+    # neither a hit nor a miss was counted
+    assert c.stats() == {'hits': 0, 'misses': 0, 'size': 1}
+
+
+def test_touch_refreshes_ttl(clock):
+    c = TTLCache(default_ttl=5)
+    c.set('k', 'v')
+    clock['t'] = 4          # near expiry
+    assert c.touch('k')      # reset ttl
+    clock['t'] = 8          # past original expiry, within the refreshed one
+    assert c.get('k') == 'v'
+
+
+def test_touch_missing_key_returns_false(clock):
+    c = TTLCache(default_ttl=10)
+    assert c.touch('nope') is False
+
+
+def test_configure_lowers_max_size_and_evicts(clock):
+    c = TTLCache(default_ttl=100, max_size=5)
+    for i in range(5):
+        c.set(i, i)
+    c.configure(max_size=2)
+    assert len(c) == 2
+    # oldest three were evicted; keys 3 and 4 remain
+    assert c.get(3) == 3
+    assert c.get(4) == 4
+
+
+def test_configure_rejects_bad_values(clock):
+    c = TTLCache(default_ttl=100)
+    with pytest.raises(ValueError):
+        c.configure(default_ttl=0)
+    with pytest.raises(ValueError):
+        c.configure(max_size=0)

--- a/website/cache.py
+++ b/website/cache.py
@@ -1,0 +1,204 @@
+"""A small in-process TTL cache.
+
+Used to memoize lookups that are expensive relative to how often they repeat
+but whose results can go stale: ZIP-to-state resolution (the range scan over
+``STATE_ZIP_RANGES``), and forthcoming per-zip tax-rule caching. The cache is
+process-local and intentionally simple — no LRU, no eviction thread, just
+time-based expiry with a size cap. For this app's read-heavy, write-rare
+pattern that's plenty; a Redis layer would be over-engineering until we have
+real multi-process traffic.
+
+Design
+------
+- **Lazy per-key expiry on read.** ``get(key)`` checks the stored entry's
+  expiry timestamp and treats an expired entry as a miss; the caller's
+  ``loader`` is invoked to repopulate. No background sweeper is needed.
+- **Optional size cap.** When ``max_size`` is set and a ``set()`` would
+  exceed it, the oldest entries are dropped first (insertion order is
+  preserved via ``dict`` ordering).
+- **Stats.** Hits and misses are counted for a cheap observability hook into
+  the home dashboard's "cache hit rate" debug panel.
+- **Thread safety.** None. Flask's dev server is single-threaded and the
+  prod WSGI workers (gunicorn sync) serialize per-worker, so each worker
+  owns its own cache. If we move to a threaded model, wrap calls in a lock.
+
+Not a replacement for the ledger or any source of truth — purely a
+read-through acceleration layer over pure functions.
+"""
+import time
+
+
+class TTLCache:
+    """A time-to-live cache mapping keys to ``(value, expires_at)`` entries.
+
+    Eviction is lazy on read: a ``get()`` for a key whose entry has expired
+    is treated as a miss and the caller's ``loader`` is invoked to
+    repopulate. Each read also sweeps any other expired entries it encounters
+    while scanning, so no separate background pruning step is required for
+    the cache to stay bounded over time.
+
+    Example::
+
+        zip_cache = TTLCache(default_ttl=3600)
+        state = zip_cache.get(zipcode, lambda: _resolve_state(zipcode))
+    """
+
+    _MISSING = object()  # sentinel for "no entry"
+
+    def __init__(self, default_ttl: float = 300.0, max_size: int = None):
+        if default_ttl <= 0:
+            raise ValueError('default_ttl must be positive')
+        if max_size is not None and max_size < 1:
+            raise ValueError('max_size must be >= 1 or None')
+        self.default_ttl = default_ttl
+        self.max_size = max_size
+        self._store: dict = {}  # key -> [value, expires_at]
+        self._hits = 0
+        self._misses = 0
+
+    # ── core read/write ──────────────────────────────────────────────────────
+
+    def get(self, key, loader=None):
+        """Return the cached value for ``key``, or compute and cache it.
+
+        If ``key`` is present and fresh, returns the stored value (a hit).
+        If ``key`` is absent or expired, increments the miss counter; when
+        ``loader`` is provided it is called to produce a value, which is
+        stored under ``key`` with the default TTL and returned. Without a
+        loader, a miss returns ``None``.
+        """
+        value = self._lookup(key)
+        if value is None:
+            self._misses += 1
+            if loader is not None:
+                value = loader()
+                self.set(key, value)
+            else:
+                return None
+        else:
+            self._hits += 1
+        return value
+
+    def _lookup(self, key):
+        """Return the stored value for ``key`` if present and fresh, else None."""
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if time.monotonic() >= expires_at:
+            # Expired — drop the stale entry so it doesn't count against size.
+            del self._store[key]
+            return None
+        return value
+
+    def set(self, key, value, ttl: float = None):
+        """Store ``value`` under ``key`` with the given TTL (or the default).
+
+        If ``max_size`` is set and the cache is full, evicts oldest entries
+        first until there's room.
+        """
+        if ttl is None:
+            ttl = self.default_ttl
+        if self.max_size is not None and key not in self._store:
+            self._evict_to_fit(1)
+        self._store[key] = [value, time.monotonic() + ttl]
+
+    def _evict_to_fit(self, slots_needed: int) -> None:
+        """Drop oldest entries until at least ``slots_needed`` are free."""
+        if self.max_size is None:
+            return
+        overflow = len(self._store) + slots_needed - self.max_size
+        if overflow <= 0:
+            return
+        # dict preserves insertion order; evict the oldest `overflow` keys.
+        for key in list(self._store.keys())[:overflow]:
+            del self._store[key]
+
+    # ── maintenance ──────────────────────────────────────────────────────────
+
+    def prune(self) -> int:
+        """Remove every expired entry in one sweep. Returns the count dropped.
+
+        Useful for periodic cleanup (e.g. once per request) rather than
+        waiting for each stale key to be queried.
+        """
+        dropped = 0
+        for key in self._store:
+            _, expires_at = self._store[key]
+            if time.monotonic() >= expires_at:
+                del self._store[key]
+                dropped += 1
+        return dropped
+
+    def clear(self) -> None:
+        """Drop all entries and reset stats."""
+        self._store.clear()
+        self._hits = 0
+        self._misses = 0
+
+    # ── introspection ────────────────────────────────────────────────────────
+
+    def peek(self, key):
+        """Return the stored value for ``key`` without touching hit/miss stats.
+
+        Returns ``None`` for a miss or an expired entry, just like ``get``
+        but without counting. Handy for assertions in tests or for the
+        debug panel when you don't want to skew the hit rate.
+        """
+        return self._lookup(key)
+
+    def touch(self, key, ttl: float = None) -> bool:
+        """Reset ``key``'s expiry as if it were just set. Returns True if the
+        key was present and refreshed, False if it was absent (no insertion).
+
+        Useful when an external signal indicates the cached value is still
+        fresh (e.g. a heartbeat) and you want to push out its TTL without
+        recomputing it.
+        """
+        if key not in self._store:
+            return False
+        if ttl is None:
+            ttl = self.default_ttl
+        self._store[key][1] = time.monotonic() + ttl
+        return True
+
+    def configure(self, default_ttl: float = None, max_size: int = None) -> None:
+        """Adjust the cache's tunables at runtime.
+
+        ``default_ttl`` and ``max_size`` are applied to subsequent operations;
+        existing entries keep their already-computed expiry timestamps. If
+        ``max_size`` is lowered below the current size, the oldest entries
+        are evicted immediately to comply.
+        """
+        if default_ttl is not None:
+            if default_ttl <= 0:
+                raise ValueError('default_ttl must be positive')
+            self.default_ttl = default_ttl
+        if max_size is not None:
+            if max_size < 1:
+                raise ValueError('max_size must be >= 1')
+            self.max_size = max_size
+            self._evict_to_fit(0)
+
+    def snapshot(self) -> dict:
+        """Return the current cache contents for debugging/inspection.
+
+        Callers should treat the result as read-only.
+        """
+        return self._store
+
+    def stats(self) -> dict:
+        """Return ``{'hits': int, 'misses': int, 'size': int}``."""
+        return {'hits': self._hits, 'misses': self._misses, 'size': len(self._store)}
+
+    @property
+    def hit_rate(self) -> float:
+        """Fraction of lookups that hit, or 0.0 when there have been none."""
+        total = self._hits + self._misses
+        return self._hits / total if total else 0.0
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __contains__(self, key) -> bool:
+        return self._lookup(key) is not None

--- a/website/tax.py
+++ b/website/tax.py
@@ -120,10 +120,20 @@ STATE_ZIP_RANGES = [
 ]
 
 
+from .cache import TTLCache
+
+
+_zip_cache = TTLCache(default_ttl=3600)
+
+
 def state_for_zip(zipcode):
     """Return the 2-letter US state code for a 5-digit zipcode, or None if unknown."""
     if not zipcode or len(zipcode) != 5 or not zipcode.isdigit():
         return None
+    return _zip_cache.get(zipcode, lambda: _resolve_state(zipcode))
+
+
+def _resolve_state(zipcode):
     z = int(zipcode)
     for state, low, high in STATE_ZIP_RANGES:
         if low <= z <= high:


### PR DESCRIPTION
## Summary
The STATE_ZIP_RANGES scan runs on every tax lookup, and on the wishlist table that's once per row per render. Add a small in-process TTL cache and route state_for_zip through it so repeated zips skip the scan.

## Changes
- **`website/cache.py`** — new module with a `TTLCache` class:
  - `get(key, loader)` read-through: returns the fresh cached value or invokes `loader`, stores, and returns it.
  - Per-key lazy expiry on read (an expired entry is a miss), plus an optional `max_size` cap that evicts oldest-first.
  - `prune()` for a periodic full sweep, `peek()` (stats-free read), `touch()` (refresh a key's TTL), `configure()` (retune at runtime), `snapshot()` and `stats()` for the debug panel.
  - Hit/miss counters and a `hit_rate` property.
- **`website/tax.py`** — `state_for_zip` now resolves through a module-level `TTLCache(default_ttl=3600)` via a small `_resolve_state` helper. ZIP-to-state is price-independent and changes never, so an hour TTL is conservative.
- **`tests/test_cache.py`** — unit tests using a controllable monotonic clock (no real sleeps): get/set/ttl expiry, custom TTL, stats and hit rate, `max_size` oldest-first eviction, `__contains__`/\`__len__\`, `peek`/`touch`/`configure`, and a no-op `prune` with no expired entries.

## Notes
- The cache is process-local with no locking — fine for the dev server and gunicorn sync workers (each worker owns its own). A threaded model would need a lock wrapper.
- No behavior change to `tax_rate`; only the ZIP→state scan is memoized.

[AGENT] review-exercise drill — intentional practice bugs — do not merge