### PR TITLE
Add concurrent batch product extraction API

### DIFF
--- a/tests/test_batch_extraction.py
+++ b/tests/test_batch_extraction.py
@@ -1,0 +1,187 @@
+"""Bulk product-extraction service and API integration tests."""
+import asyncio
+import threading
+import time
+from collections.abc import Iterator
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from flask_jwt_extended import JWTManager, create_access_token
+
+from website import db
+from website.api import api
+from website.batch_extraction import (
+    BatchExtractionError,
+    BatchExtractor,
+    MAX_BATCH_URLS,
+    ScrapedItem,
+)
+from website.models import User
+
+ResultPayload = dict[str, str | bool | ScrapedItem | None]
+BatchPayload = dict[str, int | list[ResultPayload]]
+
+
+@pytest.fixture
+def app() -> Iterator[Flask]:
+    """Create an in-memory API app."""
+    flask_app: Flask = Flask(__name__)
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    flask_app.config['JWT_SECRET_KEY'] = 'test-secret-with-enough-length-12345'
+    db.init_app(flask_app)
+    JWTManager(flask_app)
+    flask_app.register_blueprint(api, url_prefix='/api/v1')
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    """Return the API test client."""
+    return app.test_client()
+
+
+def _make_user() -> User:
+    """Persist an authenticated API user."""
+    user: User = User(
+        email='batch@example.com',
+        first_name='Batch',
+        password='x',
+        zipcode='10001',
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _token(user: User) -> str:
+    """Create a JWT for the supplied user."""
+    return create_access_token(identity=str(user.id))
+
+
+def test_service_isolates_one_scrape_failure() -> None:
+    """One failed URL does not abort successful URLs."""
+    def fake_scraper(url: str) -> ScrapedItem:
+        if 'broken' in url:
+            raise RuntimeError('store blocked this request')
+        return {'name': url.rsplit('/', 1)[-1], 'image_url': 'https://img.test/x.jpg'}
+
+    extractor: BatchExtractor = BatchExtractor(scraper=fake_scraper)
+    results = asyncio.run(extractor.extract([
+        'https://shop.test/dress',
+        'https://broken.test/item',
+    ]))
+    by_url: dict[str, ResultPayload] = {
+        result.url: result.to_dict() for result in results
+    }
+
+    assert by_url['https://shop.test/dress']['success'] is True
+    assert by_url['https://broken.test/item']['success'] is False
+    assert 'blocked' in str(by_url['https://broken.test/item']['error'])
+
+
+def test_service_enforces_concurrency_bound() -> None:
+    """The semaphore limits simultaneous synchronous scraper calls."""
+    lock: threading.Lock = threading.Lock()
+    active: int = 0
+    max_active: int = 0
+
+    def fake_scraper(url: str) -> ScrapedItem:
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.01)
+        with lock:
+            active -= 1
+        return {'name': url, 'image_url': 'https://img.test/x.jpg'}
+
+    extractor: BatchExtractor = BatchExtractor(
+        max_concurrency=2,
+        scraper=fake_scraper,
+    )
+    urls: list[str] = [f'https://shop.test/{index}' for index in range(6)]
+    results = asyncio.run(extractor.extract(urls))
+
+    assert len(results) == 6
+    assert max_active == 2
+
+
+def test_service_rejects_invalid_url_and_oversized_batch() -> None:
+    """Service validation protects non-HTTP input and batch size."""
+    extractor: BatchExtractor = BatchExtractor(scraper=lambda url: {'name': url})
+    with pytest.raises(BatchExtractionError, match='invalid URL'):
+        asyncio.run(extractor.extract(['not-a-url']))
+
+    too_many: list[str] = [
+        f'https://shop.test/{index}' for index in range(MAX_BATCH_URLS + 1)
+    ]
+    with pytest.raises(BatchExtractionError, match='no more than'):
+        asyncio.run(extractor.extract(too_many))
+
+
+def test_batch_endpoint_returns_per_url_results(
+        client: FlaskClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The authenticated endpoint exposes successes and failures together."""
+    user: User = _make_user()
+
+    def fake_scraper(url: str) -> ScrapedItem:
+        if 'broken' in url:
+            raise RuntimeError('could not extract product')
+        return {
+            'name': 'Silk Dress',
+            'brand': 'Example',
+            'price': 120.0,
+            'image_url': 'https://img.test/dress.jpg',
+        }
+
+    monkeypatch.setattr('website.batch_extraction.scrape_item', fake_scraper)
+    response = client.post(
+        '/api/v1/extract/batch',
+        json={'urls': [
+            'HTTPS://SHOP.TEST/dress#details',
+            'https://broken.test/item',
+        ]},
+        headers={'Authorization': f'Bearer {_token(user)}'},
+    )
+
+    assert response.status_code == 200
+    payload: BatchPayload = response.get_json()
+    assert payload['count'] == 2
+    assert payload['succeeded'] == 1
+    assert payload['failed'] == 1
+    results: list[ResultPayload] = payload['results']
+    by_url: dict[str, ResultPayload] = {
+        str(result['url']): result for result in results
+    }
+    assert by_url['https://shop.test/dress']['data']['name'] == 'Silk Dress'
+    assert by_url['https://broken.test/item']['success'] is False
+
+
+def test_batch_endpoint_validates_payload(client: FlaskClient) -> None:
+    """Invalid shapes and URLs return clear 400 responses."""
+    user: User = _make_user()
+    headers: dict[str, str] = {
+        'Authorization': f'Bearer {_token(user)}'
+    }
+
+    empty = client.post('/api/v1/extract/batch', json={'urls': []}, headers=headers)
+    invalid = client.post(
+        '/api/v1/extract/batch',
+        json={'urls': ['ftp://shop.test/item']},
+        headers=headers,
+    )
+    oversized = client.post(
+        '/api/v1/extract/batch',
+        json={'urls': [
+            f'https://shop.test/{index}' for index in range(MAX_BATCH_URLS + 1)
+        ]},
+        headers=headers,
+    )
+
+    assert empty.status_code == 400
+    assert invalid.status_code == 400
+    assert oversized.status_code == 400

--- a/website/api.py
+++ b/website/api.py
@@ -1,4 +1,8 @@
-from flask import Blueprint, jsonify, request
+import asyncio
+import datetime
+from urllib.parse import urlparse, urlunparse
+
+from flask import Blueprint, Response, jsonify, request
 from flask_jwt_extended import create_access_token, get_jwt_identity, jwt_required
 from werkzeug.security import generate_password_hash, check_password_hash
 from .models import User, WishItem, normalize_category, clean_text
@@ -10,7 +14,7 @@ from .purchases import (mark_purchased, needs_savings_prompt,
                         record_savings_decision, savings_feature_enabled)
 from .url_extraction import ItemDetails, scrape_item
 from .tax import taxed_price
-import datetime
+from .batch_extraction import BatchExtractionError, BatchExtractor, MAX_BATCH_URLS
 
 api = Blueprint('api', __name__)
 
@@ -381,6 +385,58 @@ def extract_url():
         print(f"URL extraction error: {e}")
         return jsonify({'success': False, 'name': None, 'price': None, 'brand': None,
                         'description': None, 'currency': None, 'image_url': None})
+
+
+@api.route('/extract/batch', methods=['POST'])
+@jwt_required()
+def extract_batch() -> Response | tuple[Response, int]:
+    """Extract product metadata for up to ten URLs in one request."""
+    body: dict[str, bool | list[str]] | None = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return jsonify({'error': 'request body must be a JSON object'}), 400
+    raw_urls: bool | list[str] | None = body.get('urls')
+    if not isinstance(raw_urls, list) or not raw_urls:
+        return jsonify({'error': 'urls must be a non-empty list'}), 400
+    if len(raw_urls) > MAX_BATCH_URLS:
+        return jsonify({
+            'error': f'urls must contain no more than {MAX_BATCH_URLS} entries'
+        }), 400
+
+    normalized_urls: list[str] = []
+    for raw_url in raw_urls:
+        if not isinstance(raw_url, str):
+            return jsonify({'error': 'each URL must be a string'}), 400
+        candidate: str = raw_url.strip()
+        parsed = urlparse(candidate)
+        if parsed.scheme.lower() not in ('http', 'https') or not parsed.netloc:
+            return jsonify({'error': f'invalid URL: {raw_url!r}'}), 400
+        normalized_urls.append(urlunparse((
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path or '/',
+            parsed.params,
+            parsed.query,
+            '',
+        )))
+
+    enrich_images: bool | list[str] = body.get('enrich_images', False)
+    if not isinstance(enrich_images, bool):
+        return jsonify({'error': 'enrich_images must be a boolean'}), 400
+
+    try:
+        results = asyncio.run(
+            BatchExtractor().extract(normalized_urls, enrich_images=enrich_images)
+        )
+    except BatchExtractionError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    succeeded: int = sum(result.success for result in results)
+    return jsonify({
+        'count': len(results),
+        'succeeded': succeeded,
+        'failed': len(results) - succeeded,
+        'results': [result.to_dict() for result in results],
+    })
 
 
 # ── Reports ───────────────────────────────────────────────────────────────────

--- a/website/batch_extraction.py
+++ b/website/batch_extraction.py
@@ -1,0 +1,146 @@
+"""Concurrent bulk product extraction for the mobile API.
+
+The existing :func:`website.url_extraction.scrape_item` function is
+synchronous and may block on HTTP or Playwright. ``BatchExtractor`` keeps that
+well-tested boundary intact while running several independent URLs concurrently
+through ``asyncio.to_thread``. A semaphore prevents one request from spawning
+an unbounded number of browser/network workers.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
+
+from .url_extraction import ItemDetails, scrape_item
+
+MAX_BATCH_URLS = 10
+DEFAULT_CONCURRENCY = 4
+MAX_CONCURRENCY = 8
+
+ScrapedValue = str | int | float | None
+ScrapedItem = dict[str, ScrapedValue]
+Scraper = Callable[[str], ScrapedItem]
+
+
+class BatchExtractionError(ValueError):
+    """Raised when batch configuration or a submitted URL is invalid."""
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """The success or failure result for one requested URL."""
+
+    url: str
+    success: bool
+    data: ScrapedItem | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, str | bool | ScrapedItem | None]:
+        """Return a JSON-serializable representation for the API response."""
+        return {
+            'url': self.url,
+            'success': self.success,
+            'data': self.data,
+            'error': self.error,
+        }
+
+
+class BatchExtractor:
+    """Extract product metadata from a bounded list of URLs concurrently.
+
+    Results are returned in the same order as the submitted URLs, including
+    duplicate URLs. Failures are isolated to their URL and do not abort the
+    rest of the batch.
+    """
+
+    def __init__(self, max_concurrency: int = DEFAULT_CONCURRENCY,
+                 scraper: Scraper | None = None) -> None:
+        """Create an extractor with a bounded worker count."""
+        if max_concurrency < 1 or max_concurrency > MAX_CONCURRENCY:
+            raise BatchExtractionError(
+                f'max_concurrency must be between 1 and {MAX_CONCURRENCY}'
+            )
+        self._semaphore = asyncio.Semaphore(max_concurrency)
+        self._scraper: Scraper = scraper or scrape_item
+
+    async def extract(self, urls: list[str],
+                      enrich_images: bool = False) -> list[ExtractionResult]:
+        """Extract every URL and return one result per input URL.
+
+        At most :data:`MAX_BATCH_URLS` URLs may be submitted. Optional image
+        enrichment performs a second asynchronous lookup only when the base
+        scraper did not return an image.
+        """
+        if not urls:
+            raise BatchExtractionError('urls must contain at least one URL')
+        if len(urls) > MAX_BATCH_URLS:
+            raise BatchExtractionError(
+                f'urls must contain no more than {MAX_BATCH_URLS} entries'
+            )
+
+        normalized_urls: list[str] = [self._normalize_url(url) for url in urls]
+        tasks: list[asyncio.Task[ExtractionResult]] = [
+            asyncio.create_task(self._extract_one(url, enrich_images))
+            for url in normalized_urls
+        ]
+        results: list[ExtractionResult] = []
+        for task in asyncio.as_completed(tasks):
+            results.append(await task)
+        return results
+
+    async def _extract_one(self, url: str,
+                           enrich_images: bool) -> ExtractionResult:
+        """Run one synchronous scrape in the thread pool and isolate errors."""
+        async with self._semaphore:
+            try:
+                data: ScrapedItem = await asyncio.to_thread(self._scraper, url)
+                if enrich_images and not data.get('image_url'):
+                    self._enrich_missing_image(data)
+                return ExtractionResult(url=url, success=True, data=data)
+            except Exception as exc:
+                return ExtractionResult(
+                    url=url,
+                    success=False,
+                    error=str(exc) or exc.__class__.__name__,
+                )
+
+    async def _enrich_missing_image(self, data: ScrapedItem) -> None:
+        """Populate ``image_url`` via the existing Google fallback."""
+        brand_value: ScrapedValue = data.get('brand')
+        name_value: ScrapedValue = data.get('name')
+        description_value: ScrapedValue = data.get('description')
+        price_value: ScrapedValue = data.get('price')
+        brand: str | None = str(brand_value) if brand_value is not None else None
+        name: str | None = str(name_value) if name_value is not None else None
+        description: str | None = (
+            str(description_value) if description_value is not None else None
+        )
+        price: str | None = str(price_value) if price_value is not None else None
+        image_url: str | None = await asyncio.to_thread(
+            ItemDetails.google_search_image_fallback,
+            brand,
+            name,
+            description,
+            price,
+        )
+        data['image_url'] = image_url
+
+    @staticmethod
+    def _normalize_url(raw_url: str) -> str:
+        """Validate and normalize one public HTTP(S) URL."""
+        if not isinstance(raw_url, str):
+            raise BatchExtractionError('each URL must be a string')
+        candidate: str = raw_url.strip()
+        parsed = urlparse(candidate)
+        if parsed.scheme.lower() not in ('http', 'https') or not parsed.netloc:
+            raise BatchExtractionError(f'invalid URL: {raw_url!r}')
+        return urlunparse((
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path or '/',
+            parsed.params,
+            parsed.query,
+            '',
+        ))


### PR DESCRIPTION
## Summary
Add a bulk extraction endpoint so the mobile client can submit several product URLs at once instead of making serial `/extract` requests.

## Changes
- Add a `BatchExtractor` service that runs the existing synchronous scraper through `asyncio.to_thread` with semaphore-bounded concurrency.
- Isolate failures per URL so one blocked retailer does not fail the whole batch.
- Add `POST /api/v1/extract/batch` with JWT auth, URL validation, a 10-item limit, and optional missing-image enrichment.
- Add service and API tests for partial failures, concurrency bounds, validation, and response counts.

## Notes
The existing single-URL endpoint and scraper implementation are unchanged.

[AGENT] review-exercise drill — intentional practice issues — do not merge
