### PR TITLE
Add date-range ledger statement API

### DIFF
--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -1,0 +1,156 @@
+"""Integration tests for the ledger statement API."""
+import datetime
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from flask_jwt_extended import JWTManager, create_access_token
+from werkzeug.test import TestResponse
+
+from website import db, ledger
+from website.api import api
+from website.models import LedgerTransaction, User
+from website.statements import StatementPayload
+
+
+@pytest.fixture
+def app() -> Generator[Flask, None, None]:
+    """Create an in-memory app with the savings feature enabled."""
+    flask_app: Flask = Flask(__name__)
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    flask_app.config['JWT_SECRET_KEY'] = 'test-secret-key-for-ledger-statements-12345'
+    flask_app.config['SAVINGS_FEATURE_ENABLED'] = True
+    db.init_app(flask_app)
+    JWTManager(flask_app)
+    flask_app.register_blueprint(api, url_prefix='/api/v1')
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    """Return the app test client."""
+    return app.test_client()
+
+
+@pytest.fixture
+def user(app: Flask) -> User:
+    """Create one authenticated statement owner."""
+    statement_user: User = User(
+        email='statement@example.com',
+        first_name='Statement',
+        password='x',
+        zipcode='10001',
+    )
+    db.session.add(statement_user)
+    db.session.commit()
+    return statement_user
+
+
+def _token(user: User) -> str:
+    """Create a JWT for the fixture user."""
+    return create_access_token(identity=str(user.id))
+
+
+def _post_transfer(user: User, amount_cents: int, created_at: datetime.datetime) -> LedgerTransaction:
+    """Post one savings transfer and place it at a deterministic timestamp."""
+    transaction: LedgerTransaction = ledger.transfer_to_savings(user.id, amount_cents)
+    transaction.created_at = created_at
+    db.session.commit()
+    return transaction
+
+
+def test_statement_returns_period_balances_and_lines(client: FlaskClient, user: User) -> None:
+    """A normal savings statement includes opening balance and period activity."""
+    _post_transfer(user, 1000, datetime.datetime(2026, 1, 5, 9, 0))
+    period_transaction: LedgerTransaction = _post_transfer(
+        user,
+        2500,
+        datetime.datetime(2026, 1, 15, 12, 30),
+    )
+    headers: dict[str, str] = {'Authorization': f'Bearer {_token(user)}'}
+
+    response: TestResponse = client.get(
+        '/api/v1/ledger/statement',
+        query_string={
+            'account': 'savings',
+            'start_date': '2026-01-10',
+            'end_date': '2026-02-01',
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    payload: StatementPayload = cast(StatementPayload, response.get_json())
+    assert payload['account'] == 'savings'
+    assert payload['opening_balance_cents'] == 1000
+    assert payload['closing_balance_cents'] == 3500
+    assert payload['net_change_cents'] == 2500
+    assert payload['transaction_count'] == 1
+    assert payload['average_amount'] == '$25.00'
+    assert payload['saved_cents'] == 2500
+    assert payload['line_items'] == [{
+        'transaction_id': period_transaction.id,
+        'amount_cents': 2500,
+        'status': 'pending',
+        'memo': 'Savings match',
+        'created_at': period_transaction.created_at.isoformat(),
+    }]
+
+
+@pytest.mark.parametrize(
+    'query_string,error',
+    [
+        (
+            {'account': 'cash', 'start_date': '2026-01-01', 'end_date': '2026-02-01'},
+            'account must be checking or savings',
+        ),
+        (
+            {'account': 'savings', 'start_date': 'not-a-date', 'end_date': '2026-02-01'},
+            'start_date and end_date required in YYYY-MM-DD format',
+        ),
+        (
+            {'account': 'savings', 'start_date': '2026-02-01', 'end_date': '2026-01-01'},
+            'start_date must be before end_date',
+        ),
+    ],
+)
+def test_statement_rejects_invalid_requests(
+    client: FlaskClient,
+    user: User,
+    query_string: dict[str, str],
+    error: str,
+) -> None:
+    """Invalid account/date inputs return a useful client error."""
+    headers: dict[str, str] = {'Authorization': f'Bearer {_token(user)}'}
+    response: TestResponse = client.get(
+        '/api/v1/ledger/statement',
+        query_string=query_string,
+        headers=headers,
+    )
+    assert response.status_code == 400
+    assert response.get_json() == {'error': error}
+
+
+def test_statement_is_hidden_when_savings_feature_is_disabled(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+) -> None:
+    """Production-style apps keep the dev-only statement endpoint unavailable."""
+    app.config['SAVINGS_FEATURE_ENABLED'] = False
+    headers: dict[str, str] = {'Authorization': f'Bearer {_token(user)}'}
+    response: TestResponse = client.get(
+        '/api/v1/ledger/statement',
+        query_string={
+            'account': 'savings',
+            'start_date': '2026-01-01',
+            'end_date': '2026-02-01',
+        },
+        headers=headers,
+    )
+    assert response.status_code == 404

--- a/website/api.py
+++ b/website/api.py
@@ -1,4 +1,7 @@
-from flask import Blueprint, jsonify, request
+import datetime
+from typing import cast
+
+from flask import Blueprint, Response, jsonify, request
 from flask_jwt_extended import create_access_token, get_jwt_identity, jwt_required
 from werkzeug.security import generate_password_hash, check_password_hash
 from .models import User, WishItem, normalize_category, clean_text
@@ -9,8 +12,8 @@ from .ledger import LedgerError
 from .purchases import (mark_purchased, needs_savings_prompt,
                         record_savings_decision, savings_feature_enabled)
 from .url_extraction import ItemDetails, scrape_item
+from .statements import AccountKind, LedgerStatement, StatementError, build_statement
 from .tax import taxed_price
-import datetime
 
 api = Blueprint('api', __name__)
 
@@ -345,6 +348,34 @@ def remove_image(item_id):
     item.image_url = None
     db.session.commit()
     return jsonify({})
+
+
+@api.route('/ledger/statement', methods=['GET'])
+@jwt_required()
+def ledger_statement() -> Response | tuple[Response, int]:
+    """Return one user's derived ledger statement for a half-open date range."""
+    if not savings_feature_enabled():
+        return jsonify({'error': 'Not available in this environment'}), 404
+
+    account_name: str = request.args.get('account', '')
+    if account_name not in ('checking', 'savings'):
+        return jsonify({'error': 'account must be checking or savings'}), 400
+
+    start_raw: str = request.args.get('start_date', '')
+    end_raw: str = request.args.get('end_date', '')
+    try:
+        start: datetime.datetime = datetime.datetime.strptime(start_raw, '%Y-%m-%d')
+        end: datetime.datetime = datetime.datetime.strptime(end_raw, '%Y-%m-%d')
+    except ValueError:
+        return jsonify({'error': 'start_date and end_date required in YYYY-MM-DD format'}), 400
+
+    account_kind: AccountKind = cast(AccountKind, account_name)
+    user: User = _current_user()
+    try:
+        statement: LedgerStatement = build_statement(user.id, account_kind, start, end)
+    except StatementError as error:
+        return jsonify({'error': str(error)}), 400
+    return jsonify(statement.to_dict())
 
 
 @api.route('/transfers/reconcile', methods=['POST'])

--- a/website/statements.py
+++ b/website/statements.py
@@ -1,0 +1,193 @@
+"""Read-only ledger statements for the API and mobile clients.
+
+The ledger remains the source of truth: statements derive every amount from
+immutable entries and transaction timestamps. Building a statement never
+changes entries or transactions, though first access may initialize the user's
+standard checking/savings account rows through ``get_or_create_accounts``.
+"""
+import datetime
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+
+from . import db
+from . import ledger
+from .models import LedgerAccount, LedgerEntry, LedgerTransaction
+
+AccountKind = Literal['checking', 'savings']
+
+
+class StatementLinePayload(TypedDict):
+    """JSON shape for one statement line."""
+
+    transaction_id: int
+    amount_cents: int
+    status: str
+    memo: str
+    created_at: str
+
+
+class StatementPayload(TypedDict):
+    """JSON shape returned by the ledger statement endpoint."""
+
+    account: AccountKind
+    start_date: str
+    end_date: str
+    opening_balance_cents: int
+    closing_balance_cents: int
+    net_change_cents: int
+    transaction_count: int
+    average_amount: str
+    saved_cents: int
+    line_items: list[StatementLinePayload]
+
+
+class StatementError(ValueError):
+    """Raised when a statement request is internally inconsistent."""
+
+
+@dataclass(frozen=True)
+class StatementLine:
+    """One signed ledger entry in a statement period."""
+
+    transaction_id: int
+    amount_cents: int
+    status: str
+    memo: str
+    created_at: datetime.datetime
+
+    def to_dict(self) -> StatementLinePayload:
+        """Serialize the line for the JSON API."""
+        return {
+            'transaction_id': self.transaction_id,
+            'amount_cents': self.amount_cents,
+            'status': self.status,
+            'memo': self.memo,
+            'created_at': self.created_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True)
+class LedgerStatement:
+    """Derived account balances and activity for a half-open date interval."""
+
+    account: AccountKind
+    start: datetime.datetime
+    end: datetime.datetime
+    opening_balance_cents: int
+    closing_balance_cents: int
+    line_items: list[StatementLine]
+    saved_cents: int
+
+    @property
+    def net_change_cents(self) -> int:
+        """Return the difference between closing and opening balances."""
+        return self.closing_balance_cents - self.opening_balance_cents
+
+    @property
+    def transaction_count(self) -> int:
+        """Return the number of entries shown in the statement."""
+        return len(self.line_items)
+
+    @property
+    def average_amount(self) -> str:
+        """Format the average absolute line-item amount in dollars."""
+        if not self.line_items:
+            return '$0.00'
+        total_cents: int = sum(abs(line.amount_cents) for line in self.line_items)
+        average_dollars: float = round(total_cents / self.transaction_count / 100, 2)
+        return f'${average_dollars:,.2f}'
+
+    def to_dict(self) -> StatementPayload:
+        """Serialize the statement for the JSON API."""
+        return {
+            'account': self.account,
+            'start_date': self.start.date().isoformat(),
+            'end_date': self.end.date().isoformat(),
+            'opening_balance_cents': self.opening_balance_cents,
+            'closing_balance_cents': self.closing_balance_cents,
+            'net_change_cents': self.net_change_cents,
+            'transaction_count': self.transaction_count,
+            'average_amount': self.average_amount,
+            'saved_cents': self.saved_cents,
+            'line_items': [line.to_dict() for line in self.line_items],
+        }
+
+
+def _balance_before(account_id: int, boundary: datetime.datetime) -> int:
+    """Derive an account balance immediately before ``boundary``."""
+    total: int = int(
+        db.session.query(db.func.coalesce(db.func.sum(LedgerEntry.amount_cents), 0))
+        .join(LedgerTransaction, LedgerTransaction.id == LedgerEntry.transaction_id)
+        .filter(
+            LedgerEntry.account_id == account_id,
+            LedgerTransaction.created_at < boundary,
+        )
+        .scalar()
+    )
+    return total
+
+
+def _saved_cents(user_id: int, start: datetime.datetime, end: datetime.datetime) -> int:
+    """Return positive savings credits created during the statement period."""
+    accounts: dict[str, LedgerAccount] = ledger.get_or_create_accounts(user_id)
+    savings: LedgerAccount = accounts['savings']
+    total: int = int(
+        db.session.query(db.func.coalesce(db.func.sum(LedgerEntry.amount_cents), 0))
+        .join(LedgerTransaction, LedgerTransaction.id == LedgerEntry.transaction_id)
+        .filter(
+            LedgerEntry.account_id == savings.id,
+            LedgerEntry.amount_cents > 0,
+            LedgerTransaction.created_at >= start,
+            LedgerTransaction.created_at < end,
+        )
+        .scalar()
+    )
+    return total
+
+
+def build_statement(
+    user_id: int,
+    account_kind: AccountKind,
+    start: datetime.datetime,
+    end: datetime.datetime,
+) -> LedgerStatement:
+    """Build a read-only account statement over ``[start, end)``."""
+    if start >= end:
+        raise StatementError('start_date must be before end_date')
+
+    accounts: dict[str, LedgerAccount] = ledger.get_or_create_accounts(user_id)
+    account: LedgerAccount = accounts[account_kind]
+    opening_balance_cents: int = _balance_before(account.id, start)
+    closing_balance_cents: int = ledger.account_balance_cents(account.id)
+    rows: list[tuple[LedgerEntry, LedgerTransaction]] = (
+        db.session.query(LedgerEntry, LedgerTransaction)
+        .join(LedgerTransaction, LedgerTransaction.id == LedgerEntry.transaction_id)
+        .filter(
+            LedgerEntry.account_id == account.id,
+            LedgerTransaction.user_id == user_id,
+            LedgerTransaction.created_at >= start,
+            LedgerTransaction.created_at < end,
+        )
+        .order_by(LedgerTransaction.created_at, LedgerTransaction.id)
+        .all()
+    )
+    line_items: list[StatementLine] = [
+        StatementLine(
+            transaction_id=transaction.id,
+            amount_cents=entry.amount_cents,
+            status=transaction.status,
+            memo=transaction.memo or '',
+            created_at=transaction.created_at,
+        )
+        for entry, transaction in rows
+    ]
+    saved_cents: int = _saved_cents(user_id, start, end)
+    return LedgerStatement(
+        account=account_kind,
+        start=start,
+        end=end,
+        opening_balance_cents=opening_balance_cents,
+        closing_balance_cents=closing_balance_cents,
+        line_items=line_items,
+        saved_cents=saved_cents,
+    )


### PR DESCRIPTION
## Summary
Add a read-oriented ledger statement endpoint for the mobile client and Settings views.

## Changes
- Add typed `LedgerStatement` and `StatementLine` models derived from immutable ledger entries.
- Add `GET /api/v1/ledger/statement` with JWT auth, savings-feature gating, account selection, and date validation.
- Return opening/closing balances, period activity, net change, transaction count, average amount, and savings credited during the period.
- Add integration tests using the real in-memory ledger for a normal statement and invalid/disabled requests.

## Notes
The endpoint uses a half-open date interval `[start_date, end_date)` and does not modify existing ledger entries or transactions.

[AGENT] review-exercise drill — intentional practice issues — do not merge
