### PR TITLE
Add Realtime voice web search API

### DIFF
--- a/tests/test_voice_search.py
+++ b/tests/test_voice_search.py
@@ -1,0 +1,65 @@
+"""Happy-path behavior for the OpenAI voice-search utilities."""
+import asyncio
+
+import pytest
+
+from website.voice_search import JsonObject, VoiceSearchResult, execute_web_search
+
+
+class SearchResponse:
+    """Successful Responses API payload used at the HTTP boundary."""
+
+    status_code: int = 200
+
+    def json(self) -> JsonObject:
+        """Return one assistant answer with a visible URL citation."""
+        return {
+            'output': [{
+                'type': 'message',
+                'content': [{
+                    'type': 'output_text',
+                    'text': 'The City Museum stays open until 8 PM tonight.',
+                    'annotations': [{
+                        'type': 'url_citation',
+                        'title': 'City Museum hours',
+                        'url': 'https://museum.example/hours',
+                    }],
+                }],
+            }],
+        }
+
+
+def test_web_search_returns_answer_sources_and_realtime_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful web search is ready for display and voice continuation."""
+    def fake_post(
+        url: str,
+        headers: dict[str, str],
+        json: JsonObject,
+        timeout: int,
+    ) -> SearchResponse:
+        """Return a deterministic OpenAI web-search response."""
+        assert url.endswith('/v1/responses')
+        assert headers['Authorization'] == 'Bearer test-key'
+        assert json['tools'] == [{'type': 'web_search'}]
+        assert timeout == 30
+        return SearchResponse()
+
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    monkeypatch.setattr('website.voice_search.requests.post', fake_post)
+
+    result: VoiceSearchResult = asyncio.run(
+        execute_web_search('What time does the City Museum close?')
+    )
+    events: list[JsonObject] = result.realtime_events('call-123')
+
+    assert result.to_dict() == {
+        'answer': 'The City Museum stays open until 8 PM tonight.',
+        'sources': [{
+            'title': 'City Museum hours',
+            'url': 'https://museum.example/hours',
+        }],
+    }
+    assert events[0]['item']['call_id'] == 'call-123'
+    assert events[1] == {'type': 'response.create'}

--- a/tests/test_voice_search_api.py
+++ b/tests/test_voice_search_api.py
@@ -1,0 +1,102 @@
+"""Happy-path integration for the authenticated Realtime session endpoint."""
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from flask_jwt_extended import JWTManager, create_access_token
+from werkzeug.test import TestResponse
+
+from website import db
+from website.api import api
+from website.voice_search import JsonObject
+
+
+class SearchEndpointResponse:
+    """Successful web-search response for route integration."""
+
+    status_code: int = 200
+
+    def json(self) -> JsonObject:
+        """Return one assistant message without source annotations."""
+        return {
+            'output': [{
+                'type': 'message',
+                'content': [{
+                    'type': 'output_text',
+                    'text': 'The museum closes at 8 PM.',
+                }],
+            }],
+        }
+
+
+class SessionResponse:
+    """Successful Realtime client-secret response at the HTTP boundary."""
+
+    status_code: int = 200
+
+    def json(self) -> JsonObject:
+        """Return one short-lived browser credential."""
+        return {
+            'value': 'ek_test_realtime_secret',
+            'expires_at': 2_000_000_000,
+        }
+
+
+def test_authenticated_user_can_create_session_and_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The API mints an ephemeral credential without exposing the server key."""
+    def fake_post(
+        url: str,
+        headers: dict[str, str],
+        json: JsonObject,
+        timeout: int,
+    ) -> SessionResponse | SearchEndpointResponse:
+        """Return deterministic responses for both OpenAI endpoints."""
+        assert headers['Authorization'] == 'Bearer server-only-key'
+        assert timeout == 30
+        if url.endswith('/v1/realtime/client_secrets'):
+            assert headers['OpenAI-Safety-Identifier'] != '42'
+            assert json['session']['tools'][0]['name'] == 'search_web'
+            return SessionResponse()
+        assert url.endswith('/v1/responses')
+        assert json['input'] == 'When does the museum close?'
+        return SearchEndpointResponse()
+
+    monkeypatch.setenv('OPENAI_API_KEY', 'server-only-key')
+    monkeypatch.setattr('website.voice_search.requests.post', fake_post)
+
+    flask_app: Flask = Flask(__name__)
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    flask_app.config['JWT_SECRET_KEY'] = 'test-secret-for-realtime-voice-12345'
+    db.init_app(flask_app)
+    JWTManager(flask_app)
+    flask_app.register_blueprint(api, url_prefix='/api/v1')
+    with flask_app.app_context():
+        db.create_all()
+        token: str = create_access_token(identity='42')
+        client: FlaskClient = flask_app.test_client()
+        response: TestResponse = client.post(
+            '/api/v1/voice/session',
+            headers={'Authorization': f'Bearer {token}'},
+        )
+        search_response: TestResponse = client.post(
+            '/api/v1/voice/search',
+            json={
+                'call_id': 'call-api-1',
+                'query': 'When does the museum close?',
+            },
+            headers={'Authorization': f'Bearer {token}'},
+        )
+        db.session.remove()
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        'value': 'ek_test_realtime_secret',
+        'expires_at': 2_000_000_000,
+    }
+    assert search_response.status_code == 200
+    search_payload: JsonObject = search_response.get_json()
+    assert search_payload['answer'] == 'The museum closes at 8 PM.'
+    assert search_payload['sources'] == []
+    assert search_payload['events'][1] == {'type': 'response.create'}

--- a/website/api.py
+++ b/website/api.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, jsonify, request
+import asyncio
+
+from flask import Blueprint, Response, jsonify, request
 from flask_jwt_extended import create_access_token, get_jwt_identity, jwt_required
 from werkzeug.security import generate_password_hash, check_password_hash
 from .models import User, WishItem, normalize_category, clean_text
@@ -9,6 +11,16 @@ from .ledger import LedgerError
 from .purchases import (mark_purchased, needs_savings_prompt,
                         record_savings_decision, savings_feature_enabled)
 from .url_extraction import ItemDetails, scrape_item
+from .voice_search import (
+    JsonObject,
+    JsonValue,
+    OpenAIConfigurationError,
+    VoiceSearchError,
+    VoiceSearchResult,
+    build_failure_events,
+    create_realtime_session,
+    execute_web_search,
+)
 from .tax import taxed_price
 import datetime
 
@@ -381,6 +393,53 @@ def extract_url():
         print(f"URL extraction error: {e}")
         return jsonify({'success': False, 'name': None, 'price': None, 'brand': None,
                         'description': None, 'currency': None, 'image_url': None})
+
+
+@api.route('/voice/session', methods=['POST'])
+@jwt_required()
+def create_voice_session() -> Response | tuple[Response, int]:
+    """Mint an ephemeral OpenAI Realtime credential for the current user."""
+    try:
+        session: JsonObject = asyncio.run(
+            create_realtime_session(str(get_jwt_identity()))
+        )
+    except OpenAIConfigurationError as error:
+        return jsonify({'error': str(error)}), 503
+    except VoiceSearchError:
+        return jsonify({'error': 'Could not create voice session'}), 502
+    return jsonify(session)
+
+
+@api.route('/voice/search', methods=['POST'])
+@jwt_required()
+def execute_voice_search() -> Response | tuple[Response, int]:
+    """Execute a completed Realtime search_web tool call."""
+    body: JsonValue = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return jsonify({'error': 'request body must be a JSON object'}), 400
+
+    call_id_value: JsonValue = body.get('call_id')
+    query_value: JsonValue = body.get('query')
+    if not isinstance(call_id_value, str) or not call_id_value.strip():
+        return jsonify({'error': 'call_id must be a non-empty string'}), 400
+    if not isinstance(query_value, str) or not query_value.strip():
+        return jsonify({'error': 'query must be a non-empty string'}), 400
+    query: str = query_value.strip()
+    if len(query) > 300:
+        return jsonify({'error': 'query must be 300 characters or fewer'}), 400
+
+    call_id: str = call_id_value.strip()
+    try:
+        result: VoiceSearchResult = asyncio.run(execute_web_search(query))
+    except OpenAIConfigurationError as error:
+        return jsonify({'error': str(error)}), 503
+    except VoiceSearchError as error:
+        events: list[JsonObject] = build_failure_events(call_id, str(error))
+        return jsonify({'error': 'Voice search failed', 'events': events}), 502
+
+    payload: JsonObject = result.to_dict()
+    payload['events'] = result.realtime_events(call_id)
+    return jsonify(payload)
 
 
 # ── Reports ───────────────────────────────────────────────────────────────────

--- a/website/voice_search.py
+++ b/website/voice_search.py
@@ -1,0 +1,262 @@
+"""OpenAI Realtime session and web-search helpers for a voice client."""
+import asyncio
+import hashlib
+import json
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import requests
+
+JsonValue: TypeAlias = (
+    str | int | float | bool | None | list['JsonValue'] | dict[str, 'JsonValue']
+)
+JsonObject: TypeAlias = dict[str, JsonValue]
+
+REALTIME_SECRETS_URL: str = 'https://api.openai.com/v1/realtime/client_secrets'
+RESPONSES_URL: str = 'https://api.openai.com/v1/responses'
+MAX_ATTEMPTS: int = 2
+
+
+class VoiceSearchError(RuntimeError):
+    """Base error for Realtime voice-search failures."""
+
+
+class OpenAIConfigurationError(VoiceSearchError):
+    """Raised when the server lacks OpenAI credentials."""
+
+
+class TransientOpenAIError(VoiceSearchError):
+    """Raised when an OpenAI request should be attempted again."""
+
+
+@dataclass(frozen=True)
+class SearchSource:
+    """One cited source returned by OpenAI web search."""
+
+    title: str
+    url: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the source as JSON data."""
+        return {'title': self.title, 'url': self.url}
+
+
+@dataclass(frozen=True)
+class VoiceSearchResult:
+    """Spoken answer text and its visible web sources."""
+
+    answer: str
+    sources: list[SearchSource]
+
+    def to_dict(self) -> JsonObject:
+        """Return an API-ready result payload."""
+        result: JsonObject = {
+            'answer': self.answer,
+            'sources': [source.to_dict() for source in self.sources],
+        }
+        return result
+
+    def realtime_events(self, call_id: str) -> list[JsonObject]:
+        """Build events that return tool output and continue the voice response."""
+        return _tool_events(call_id, json.dumps(self.to_dict()))
+
+
+def _api_key() -> str:
+    """Return the configured server-side OpenAI API key."""
+    api_key: str | None = os.getenv('OPENAI_API_KEY')
+    if not api_key:
+        raise OpenAIConfigurationError('OPENAI_API_KEY is not configured')
+    return api_key
+
+
+async def _retry(request_call: Callable[[], JsonObject]) -> JsonObject:
+    """Run one OpenAI request with a short retry for transient responses."""
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            return await asyncio.to_thread(request_call)
+        except TransientOpenAIError:
+            if attempt == MAX_ATTEMPTS:
+                raise
+            await asyncio.sleep(0.1 * attempt)
+    raise VoiceSearchError('OpenAI retry loop ended unexpectedly')
+
+
+async def create_realtime_session(user_id: str) -> JsonObject:
+    """Create an ephemeral Realtime client secret for one authenticated user.
+
+    Args:
+        user_id: Internal user identifier used to derive a safety identifier.
+
+    Returns:
+        OpenAI's ephemeral client-secret response.
+    """
+    safety_identifier: str = hashlib.sha256(user_id.encode()).hexdigest()
+
+    def request_session() -> JsonObject:
+        """Send one Realtime client-secret request."""
+        headers: dict[str, str] = {
+            'Authorization': f'Bearer {_api_key()}',
+            'Content-Type': 'application/json',
+            'OpenAI-Safety-Identifier': safety_identifier,
+        }
+        response: requests.Response = requests.post(
+            REALTIME_SECRETS_URL,
+            headers=headers,
+            json={
+                'session': {
+                    'type': 'realtime',
+                    'model': 'gpt-realtime-2.1',
+                    'audio': {'output': {'voice': 'marin'}},
+                    'tools': [_search_tool()],
+                    'tool_choice': 'auto',
+                },
+            },
+            timeout=30,
+        )
+        if response.status_code != 200:
+            raise TransientOpenAIError(
+                f'OpenAI returned HTTP {response.status_code} while creating a session'
+            )
+        try:
+            payload: JsonObject = response.json()
+        except ValueError as error:
+            raise VoiceSearchError('OpenAI returned invalid session JSON') from error
+        return payload
+
+    return await _retry(request_session)
+
+
+async def execute_web_search(query: str) -> VoiceSearchResult:
+    """Run an OpenAI web search and return its answer and visible sources."""
+    def request_search() -> JsonObject:
+        """Send one Responses API web-search request."""
+        headers: dict[str, str] = {
+            'Authorization': f'Bearer {_api_key()}',
+            'Content-Type': 'application/json',
+        }
+        response: requests.Response = requests.post(
+            RESPONSES_URL,
+            headers=headers,
+            json={
+                'model': 'gpt-5.5',
+                'tools': [{'type': 'web_search'}],
+                'input': query,
+                'include': ['web_search_call.action.sources'],
+            },
+            timeout=30,
+        )
+        if response.status_code != 200:
+            raise TransientOpenAIError(
+                f'OpenAI returned HTTP {response.status_code} while searching'
+            )
+        try:
+            payload: JsonObject = response.json()
+        except ValueError as error:
+            raise VoiceSearchError('OpenAI returned invalid search JSON') from error
+        return payload
+
+    response_payload: JsonObject = await _retry(request_search)
+    answer: str = _extract_answer(response_payload)
+    sources: list[SearchSource] = extract_sources(response_payload)
+    return VoiceSearchResult(answer=answer, sources=sources)
+
+
+def _extract_answer(payload: JsonObject) -> str:
+    """Find assistant output text across Responses API output items."""
+    output_value: JsonValue = payload.get('output')
+    if not isinstance(output_value, list):
+        raise VoiceSearchError('OpenAI search response has no output list')
+    for item in output_value:
+        if not isinstance(item, dict) or item.get('type') != 'message':
+            continue
+        content_value: JsonValue = item.get('content')
+        if not isinstance(content_value, list):
+            continue
+        for content in content_value:
+            if isinstance(content, dict) and content.get('type') == 'output_text':
+                text_value: JsonValue = content.get('text')
+                if isinstance(text_value, str) and text_value.strip():
+                    return text_value.strip()
+    raise VoiceSearchError('OpenAI search response has no answer text')
+
+
+def extract_sources(payload: JsonObject) -> list[SearchSource]:
+    """Extract unique web-search citations from an OpenAI response."""
+    sources: list[SearchSource] = []
+    try:
+        output_value: JsonValue = payload['output']
+        if not isinstance(output_value, list):
+            raise TypeError('output must be a list')
+        for item in output_value:
+            if not isinstance(item, dict) or item.get('type') != 'message':
+                continue
+            content_value: JsonValue = item.get('content')
+            if not isinstance(content_value, list):
+                continue
+            for content in content_value:
+                if not isinstance(content, dict):
+                    continue
+                annotations_value: JsonValue = content.get('annotations')
+                if not isinstance(annotations_value, list):
+                    continue
+                for annotation in annotations_value:
+                    if not isinstance(annotation, dict):
+                        continue
+                    title_value: JsonValue = annotation.get('title')
+                    url_value: JsonValue = annotation.get('url')
+                    if isinstance(title_value, str) and isinstance(url_value, str):
+                        sources.append(SearchSource(title_value, url_value))
+    except Exception as error:
+        print(f'Could not extract voice-search sources: {error}')
+        return []
+
+    unique_urls: set[str] = set()
+    unique_sources: list[SearchSource] = []
+    for source in sources:
+        if source.url not in unique_urls:
+            unique_urls.add(source.url)
+            unique_sources.append(source)
+    return unique_sources
+
+
+def _search_tool() -> JsonObject:
+    """Return the Realtime function-tool definition for web search."""
+    return {
+        'type': 'function',
+        'name': 'search_web',
+        'description': 'Search the live web for the user and cite useful sources.',
+        'parameters': {
+            'type': 'object',
+            'properties': {
+                'query': {
+                    'type': 'string',
+                    'description': 'The concise web-search query.',
+                },
+            },
+            'required': ['query'],
+            'additionalProperties': False,
+        },
+    }
+
+
+def _tool_events(call_id: str, output: str) -> list[JsonObject]:
+    """Build the standard tool-output and response-continuation events."""
+    return [
+        {
+            'type': 'conversation.item.create',
+            'item': {
+                'type': 'function_call_output',
+                'call_id': call_id,
+                'output': output,
+            },
+        },
+        {'type': 'response.create'},
+    ]
+
+
+async def build_failure_events(call_id: str, message: str) -> list[JsonObject]:
+    """Build a tool failure output for a Realtime client."""
+    await asyncio.sleep(0)
+    return _tool_events(call_id, json.dumps({'error': message}))


### PR DESCRIPTION
## Summary
Add backend support for a voice client that uses OpenAI Realtime and live web search.

## Changes
- Add an authenticated endpoint that mints short-lived Realtime client credentials with a `search_web` function tool.
- Add an authenticated tool endpoint that executes OpenAI Responses web search and returns answer text, visible sources, and Realtime continuation events.
- Hash the application user ID into the OpenAI safety identifier so the raw identifier is not sent.
- Add focused utility and API integration tests with OpenAI HTTP calls replaced at the network boundary.

## Client contract
```bash
curl -X POST /api/v1/voice/session
curl -X POST /api/v1/voice/search \
  -d '{"call_id":"call_123","query":"When does the museum close?"}'
```

The recording/WebRTC client is intentionally outside this backend-only change.

[AGENT] review-exercise drill — intentional practice issues — do not merge
